### PR TITLE
fix wrong keystate for keycodes higher than 255

### DIFF
--- a/template/template.cpp
+++ b/template/template.cpp
@@ -28,7 +28,7 @@ static bool hasFocus = true, running = true;
 static GLTexture* renderTarget = 0;
 static int scrwidth = 0, scrheight = 0;
 static TheApp* app = 0;
-uint keystate[256] = { 0 };
+uint keystate[350] = { 0 };
 
 // static member data for instruction set support class
 static const CPUCaps cpucaps;
@@ -40,7 +40,7 @@ GLTexture* GetRenderTarget() { return renderTarget; }
 bool WindowHasFocus() { return hasFocus; }
 
 // provide access to key state array
-bool IsKeyDown( const uint key ) { return keystate[key & 255] == 1; }
+bool IsKeyDown( const uint key ) { return keystate[key] == 1; }
 
 // GLFW callbacks
 void InitRenderTarget( int w, int h )
@@ -56,8 +56,8 @@ void ReshapeWindowCallback( GLFWwindow*, int w, int h )
 void KeyEventCallback( GLFWwindow*, int key, int, int action, int )
 {
 	if (key == GLFW_KEY_ESCAPE) running = false;
-	if (action == GLFW_PRESS) { if (app) if (key >= 0) app->KeyDown( key ); keystate[key & 255] = 1; }
-	else if (action == GLFW_RELEASE) { if (app) if (key >= 0) app->KeyUp( key ); keystate[key & 255] = 0; }
+	if (action == GLFW_PRESS) { if (app) if (key >= 0) app->KeyDown( key ); keystate[key] = 1; }
+	else if (action == GLFW_RELEASE) { if (app) if (key >= 0) app->KeyUp( key ); keystate[key] = 0; }
 }
 void CharEventCallback( GLFWwindow*, uint ) { /* nothing here yet */ }
 void WindowFocusCallback( GLFWwindow*, int focused ) { hasFocus = (focused == GL_TRUE); }

--- a/template/template.cpp
+++ b/template/template.cpp
@@ -28,7 +28,7 @@ static bool hasFocus = true, running = true;
 static GLTexture* renderTarget = 0;
 static int scrwidth = 0, scrheight = 0;
 static TheApp* app = 0;
-uint keystate[350] = { 0 };
+uint keystate[512] = { 0 };
 
 // static member data for instruction set support class
 static const CPUCaps cpucaps;
@@ -40,7 +40,7 @@ GLTexture* GetRenderTarget() { return renderTarget; }
 bool WindowHasFocus() { return hasFocus; }
 
 // provide access to key state array
-bool IsKeyDown( const uint key ) { return keystate[key] == 1; }
+bool IsKeyDown( const uint key ) { return keystate[key & 511] == 1; }
 
 // GLFW callbacks
 void InitRenderTarget( int w, int h )
@@ -56,8 +56,8 @@ void ReshapeWindowCallback( GLFWwindow*, int w, int h )
 void KeyEventCallback( GLFWwindow*, int key, int, int action, int )
 {
 	if (key == GLFW_KEY_ESCAPE) running = false;
-	if (action == GLFW_PRESS) { if (app) if (key >= 0) app->KeyDown( key ); keystate[key] = 1; }
-	else if (action == GLFW_RELEASE) { if (app) if (key >= 0) app->KeyUp( key ); keystate[key] = 0; }
+	if (action == GLFW_PRESS) { if (app) if (key >= 0) app->KeyDown( key ); keystate[key & 511] = 1; }
+	else if (action == GLFW_RELEASE) { if (app) if (key >= 0) app->KeyUp( key ); keystate[key & 511] = 0; }
 }
 void CharEventCallback( GLFWwindow*, uint ) { /* nothing here yet */ }
 void WindowFocusCallback( GLFWwindow*, int focused ) { hasFocus = (focused == GL_TRUE); }


### PR DESCRIPTION
KeyCodes in GLFW (version 3.4, used in the template) start from 32 and end at 348. The size of the keystate array in the template.cpp was 256 and [key & 255] was being used for indexing. Making keys with a larger number of keycodes being treated the same as their equivalent of [key & 255]. For example, numpad_1 (keycode 321) would behave the same as the "A" key (keycode 65). By increasing the size of the array to a number bigger than or equal to 348 and removing & from indexing, this bug/behavior can be avoided.