### PR TITLE
Fixed passing of incorrect parameter in glBindVertexArray() call

### DIFF
--- a/template/opengl.cpp
+++ b/template/opengl.cpp
@@ -83,7 +83,7 @@ void DrawQuad()
 		static const GLfloat verts[] = { -1, 1, 1, 1, -1, -1, 1, 1, -1, -1, 1, -1 };
 		GLuint vbo = CreateVBO( verts, sizeof( verts ) );
 		glGenVertexArrays( 1, &vao );
-		glBindVertexArray( vbo );
+		glBindVertexArray( vao );
 		glEnableVertexAttribArray( 0 );
 		glBindBuffer( GL_ARRAY_BUFFER, vbo );
 		glVertexAttribPointer( 0, 2, GL_FLOAT, GL_FALSE, 0, NULL );


### PR DESCRIPTION
The DrawQuad() function calls glBindVertexArray() but incorrectly passes "vbo" as array name/id instead of the correct "vao." This submission fixes that.