### PR TITLE
Fixed implementation of slerp

### DIFF
--- a/template/tmpl8math.h
+++ b/template/tmpl8math.h
@@ -907,7 +907,7 @@ public:
 		else
 		{
 			float angle = acosf( cosTheta );
-			float s1 = sinf( 1 - t ), s2 = sinf( t * angle ), s3 = sinf( angle );
+			float s1 = sinf(1 - t) * angle, s2 = sinf(t * angle), s3 = sinf(angle);
 			r.w = (s1 * a.w + s2 * r.w) / s3;
 			r.x = (s1 * a.x + s2 * r.x) / s3;
 			r.y = (s1 * a.y + s2 * r.y) / s3;

--- a/template/tmpl8math.h
+++ b/template/tmpl8math.h
@@ -907,7 +907,7 @@ public:
 		else
 		{
 			float angle = acosf( cosTheta );
-			float s1 = sinf(1 - t) * angle, s2 = sinf(t * angle), s3 = sinf(angle);
+			float s1 = sinf((1 - t) * angle), s2 = sinf(t * angle), s3 = sinf(angle);
 			r.w = (s1 * a.w + s2 * r.w) / s3;
 			r.x = (s1 * a.x + s2 * r.x) / s3;
 			r.y = (s1 * a.y + s2 * r.y) / s3;


### PR DESCRIPTION
Fixed the implementation of slerp, 
in the blog post it is referenced from it multiplies the first sine by angle
![image](https://github.com/user-attachments/assets/c6a945c7-c509-4a7c-ab67-69f6491fbacb)
which was not implemented causing slerp to break at larger rotations